### PR TITLE
Add section of readme for related resources/code/projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,37 @@ Please help us out as you go in setting things up by improving the deployment co
 * PRs improving either documentation or deployment code are welcome, but please submit an issue to discuss before making any substantial code changes
 * After you've made an issue, you can try to chat folks up at https://gitter.im/pol-is/polisDeployment
 
+## Related Resources
 
+This section is for code and data resources related to pol.is.
+
+- [**`audreyt/polis-tally`.**][polis-tally] Utility tool for converting
+  zipped pol.is exports into a simpler CSV/JSON format.
+- [**`OpenSourcePolitics/decidim-efb`.**][decidim-module] A module for
+  intergrating pol.is into the Decidim participatory democracy framework.
+- [**`patcon/polis-api-proxy`.**][api-proxy] API proxy for experimenting
+  with different API design choices.
+- [**`CivicTechTO/MyDem0cracy.ca-site`.**][mydem0cracy] A sample
+  micro-site for wrapping a single Pol.is conversation.
+- [**`patcon/trump-polis-twitter-bot`.**][twitter-bot] Twitter bot that creates and
+  links a Pol.is conversation for each tweet by a specific user.
+- [**`ForaDoEixo/wp-pol-is`.**][wp-plugin] Wordpress plugin for
+  embedding Pol.is conversations.
+- [**`colinmegill/conference`.**][conf-site] A sample mini-site for gathering
+  reactions during multi-session live event.
+- [**`padagraph/vTaiwanAirBnbImporter`.**][padagraph-importer]
+  Experimental importer for bringing Pol.is export data into
+[padagraph.io](http://padagraph.io).
+- [**`conversa-app/conversa.cc`.**][conversa] An
+  unofficial, experimental Pol.is frontend client built on the Ruby on
+  Rails framework.
+
+   [polis-tally]: https://github.com/audreyt/polis-tally
+   [decidim-module]: https://github.com/OpenSourcePolitics/decidim-efb
+   [api-proxy]: https://github.com/patcon/polis-api-proxy
+   [mydem0cracy]: https://github.com/CivicTechTO/MyDem0cracy.ca-site
+   [twitter-bot]: https://github.com/patcon/trump-polis-twitter-bot
+   [wp-plugin]: https://github.com/ForaDoEixo/wp-pol-is
+   [conf-site]: https://github.com/colinmegill/conference
+   [padagraph-importer]: https://github.com/padagraph/vTaiwanAirBnbImporter
+   [conversa]: https://github.com/conversa-app/conversa.cc

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This section is for code and data resources related to pol.is.
 - [**`conversa-app/conversa.cc`.**][conversa] An
   unofficial, experimental Pol.is frontend client built on the Ruby on
   Rails framework.
+  - [**`misscs/fennecs`.**][fennecs] New Pol.is interface sketches.
 - [**`uzzal2k5/polis_container`.**][polis-container] Alternative docker
   setup using Docker Swarm.
 
@@ -109,3 +110,4 @@ This section is for code and data resources related to pol.is.
    [padagraph-importer]: https://github.com/padagraph/vTaiwanAirBnbImporter
    [conversa]: https://github.com/conversa-app/conversa.cc
    [polis-container]: https://github.com/uzzal2k5/polis_container
+   [fennecs]: https://github.com/misscs/fennecs

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ TODO Compile complete starter template somewhere in this repo...
 ## Docker deployment
 
 * There's a docker-compose.yml file in https://github.com/pol-is/polisServer/blob/master/docker-compose.yml which has some instructions on running a partial dev environment with docker-compose.
-* Some one else did some dockerization work here https://github.com/uzzal2k5/polis_container.
+* Outside contributor [**@uzzal2k5**](https://github.com/uzzal2k5) has
+  created some unofficial dockerization work at [`uzzal2k5/polis_container`][polis-container].
 
 Ultimately, it would be great if all of this content was merged into this `polis-deploy` repo.
 
@@ -95,6 +96,8 @@ This section is for code and data resources related to pol.is.
 - [**`conversa-app/conversa.cc`.**][conversa] An
   unofficial, experimental Pol.is frontend client built on the Ruby on
   Rails framework.
+- [**`uzzal2k5/polis_container`.**][polis-container] Alternative docker
+  setup using Docker Swarm.
 
    [polis-tally]: https://github.com/audreyt/polis-tally
    [decidim-module]: https://github.com/OpenSourcePolitics/decidim-efb
@@ -105,3 +108,4 @@ This section is for code and data resources related to pol.is.
    [conf-site]: https://github.com/colinmegill/conference
    [padagraph-importer]: https://github.com/padagraph/vTaiwanAirBnbImporter
    [conversa]: https://github.com/conversa-app/conversa.cc
+   [polis-container]: https://github.com/uzzal2k5/polis_container


### PR DESCRIPTION
Lots of these are hard to track down, so hopefully listing them can give people inspiration or an idea of existing efforts that passionate people are/were working on :)

Not sure "deploy" feels like the right place, but it's the closest thing we have to a full "meta" repo. (polis-issues` feels much too transient, and `polis-documentation` is too official.)